### PR TITLE
Task uplift

### DIFF
--- a/.github/workflows/BuildAndTestOnEveryPush.yml
+++ b/.github/workflows/BuildAndTestOnEveryPush.yml
@@ -29,4 +29,4 @@ jobs:
       run: dotnet pack --configuration Release --include-source
       
     - name: Push NuGet package to the testfeed
-      run: dotnet nuget push Frends.Community.AWS.Http\bin\Release\Frends.Community.AWS.Http.*.nupkg  --api-key ${{ secrets.COMMUNITY_FEED_API_KEY }} --source https://www.myget.org/F/frends-community-test/api/v2/package --symbol-source https://www.myget.org/F/frends-community-test/symbols/api/v2/package
+      run: dotnet nuget push Frends.Community.AWS.Http\bin\Release\Frends.Community.AWS.Http.*.nupkg  --api-key ${{ secrets.COMMUNITY_FEED_API_KEY }} --source https://www.myget.org/F/frends-community-test/api/v2/package

--- a/Frends.Community.AWS.Http/Frends.Community.AWS.Http.csproj
+++ b/Frends.Community.AWS.Http/Frends.Community.AWS.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
+	<TargetFrameworks>netstandard2.0;net471;net6.0;net8.0</TargetFrameworks>
     <authors>HiQ Finland</authors>
     <copyright>HiQ Finland</copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -9,7 +9,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.0.2</Version>
+    <Version>0.0.3</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,10 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwsSignatureVersion4" Version="1.3.1" />
+    <PackageReference Include="AwsSignatureVersion4" Version="1.2.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
 </Project>
-

--- a/README.md
+++ b/README.md
@@ -89,3 +89,4 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | Version | Changes |
 | ------- | ------- |
 | 0.0.1   | Development still going on. |
+| 0.0.3   | Targeted to .NET6 and 8 and updated AwsSignatureVersion4 to 1.2.0 and System.ComponentModel.Annotations to 5.0.0. |


### PR DESCRIPTION
Targeted to .NET6 and 8 and updated AwsSignatureVersion4 to 1.2.0 (newest one that required no refactoring to code) and System.ComponentModel.Annotations to 5.0.0.